### PR TITLE
Allow iterating over empty query results

### DIFF
--- a/queries/results.py
+++ b/queries/results.py
@@ -41,6 +41,9 @@ class Results(object):
         :rtype: mixed
 
         """
+        if not self.cursor.rowcount:
+            raise StopIteration
+
         self._rewind()
         for row in self.cursor:
             yield row
@@ -97,6 +100,9 @@ class Results(object):
         :rtype: list
 
         """
+        if not self.cursor.rowcount:
+            return []
+
         self.cursor.scroll(0, 'absolute')
         return self.cursor.fetchall()
 

--- a/tests/results_tests.py
+++ b/tests/results_tests.py
@@ -41,6 +41,12 @@ class ResultsTestCase(unittest.TestCase):
         _row = self.obj[1]
         self.cursor.fetchone.assert_called_once_with()
 
+    def test_iter_on_empty(self):
+        self.cursor.rowcount = 0
+        with mock.patch.object(self.obj, '_rewind') as rewind:
+            [x for x in self.obj]
+            assert not rewind.called, '_rewind should not be called on empty result'
+
     def test_iter_rewinds(self):
         self.cursor.__iter__ = mock.Mock(return_value=iter([1, 2, 3]))
         with mock.patch.object(self.obj, '_rewind') as rewind:
@@ -98,6 +104,13 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_free_raises_exception(self):
         self.assertRaises(NotImplementedError, self.obj.free)
+
+    def test_items_returns_on_empty(self):
+        self.cursor.rowcount = 0
+        self.cursor.scroll = mock.Mock()
+        self.cursor.fetchall = mock.Mock()
+        self.obj.items()
+        assert not self.cursor.scroll.called, 'Cursor.scroll should not be called on empty result'
 
     def test_items_invokes_scroll(self):
         self.cursor.scroll = mock.Mock()


### PR DESCRIPTION
Added an ability to iterate on empty query results. And a couple of, probably, incorrect tests for this condition.

Previously it was causing psycopg2.ProgrammingError: scroll destination out of bounds. One could overcome this by checking for truthy result before iterating, but I'm not keen.
