### PR TITLE
Pool close fixes

### DIFF
--- a/queries/pool.py
+++ b/queries/pool.py
@@ -156,7 +156,7 @@ class Pool(object):
 
     def close(self):
         """Close the pool by closing and removing all of the connections"""
-        for cid in self.connections:
+        for cid in self.connections.keys():
             self.remove(self.connections[cid].handle)
         LOGGER.debug('Pool %s closed', self.id)
 

--- a/tests/pool_tests.py
+++ b/tests/pool_tests.py
@@ -108,7 +108,8 @@ class PoolTests(unittest.TestCase):
         psycopg2_conns = [mock.Mock(), mock.Mock()]
         [obj.add(conn) for conn in psycopg2_conns]
         obj.close()
-        obj.remove.assert_hass_calls(psycopg2_conns)
+        psycopg2_calls = [mock.call(c) for c in psycopg2_conns]
+        obj.remove.assert_has_calls(psycopg2_calls)
 
     def test_free_invokes_connection_free(self):
         obj = pool.Pool(str(uuid.uuid4()))


### PR DESCRIPTION
This PR fixes a bug in pool.close() that occurs when deleting while iterating over a dictionary as well as a typo in a test assertion.