### PR TITLE
Properly cast the environment variable as an integer

### DIFF
--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -8,7 +8,7 @@ The core `queries.Queries` class will automatically register support for UUIDs,
 Unicode and Unicode arrays.
 
 """
-__version__ = '1.7.2'
+__version__ = '1.7.3'
 version = __version__
 
 import logging

--- a/queries/pool.py
+++ b/queries/pool.py
@@ -11,7 +11,7 @@ import weakref
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_IDLE_TTL = 60
-DEFAULT_MAX_SIZE = os.environ.get('QUERIES_MAX_POOL_SIZE', 1)
+DEFAULT_MAX_SIZE = int(os.environ.get('QUERIES_MAX_POOL_SIZE', 1))
 
 
 class Connection(object):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Topic :: Software Development :: Libraries']
 
 setup(name='queries',
-      version='1.7.2',
+      version='1.7.3',
       description="Simplified PostgreSQL client built upon Psycopg2",
       maintainer="Gavin M. Roy",
       maintainer_email="gavinmroy@gmail.com",


### PR DESCRIPTION
I've neglected to cast the env var as an integer which results in the pool size limit not being respected.