### PR TITLE
Set a minimum pin on psycopg2

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 coverage
 mock
 nose
-psycopg2
+psycopg2>=2.5.1
 python-coveralls
 tornado

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ target = platform.python_implementation()
 if target == 'PyPy':
     install_requires = ['psycopg2ct']
 else:
-    install_requires = ['psycopg2']
+    install_requires = ['psycopg2>=2.5.1']
 
 # Install tornado if generating docs on readthedocs
 if os.environ.get('READTHEDOCS', None) == 'True':


### PR DESCRIPTION
There is a bug in psycopg2==2.4.5 where it raises a `TypeError` if the
`name` parameter passed to the `connection.cursor` method is None,
despite the fact the default argument is `None`.  When queries creates
a new Session it passes `None` to the cursor function and explodes.
This behavior is fixed in versions later than 2.5.1.

To test this PR out locally you'll need to `pip install psycopg2==2.4.5` 
and create a new Session, `queries.Session()`