### PR TITLE
Propagate exceptions from PoolManager.add.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 - 2015 Gavin M. Roy
+Copyright (c) 2014 - 2016 Gavin M. Roy
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Queries'
-copyright = u'2014 - 2015, Gavin M. Roy'
+copyright = u'2014 - 2016, Gavin M. Roy'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,7 @@
 Version History
 ===============
+- 1.8.10 2016-06-14
+  - Propagate PoolManager exceptions from TornadoSession (#20) - Fix by Dave Shawley
 - 1.8.9 2015-11-11
   - Move to psycopg2cffi for PyPy support
 - 1.7.5 2015-09-03

--- a/queries/__init__.py
+++ b/queries/__init__.py
@@ -8,7 +8,7 @@ The core `queries.Queries` class will automatically register support for UUIDs,
 Unicode and Unicode arrays.
 
 """
-__version__ = '1.8.4'
+__version__ = '1.8.10'
 version = __version__
 
 import logging

--- a/queries/tornado_session.py
+++ b/queries/tornado_session.py
@@ -312,8 +312,14 @@ class TornadoSession(session.Session):
 
             else:
 
-                # Add the connection to the pool
-                self._pool_manager.add(self.pid, connection)
+                try:
+                    # Add the connection to the pool
+                    self._pool_manager.add(self.pid, connection)
+                except Exception as error:
+                    LOGGER.exception('Failed to add %r to the pool', self.pid)
+                    future.set_exception(error)
+                    return
+
                 self._pool_manager.lock(self.pid, connection, self)
 
                 # Added in because psycopg2ct connects and leaves the

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Topic :: Software Development :: Libraries']
 
 setup(name='queries',
-      version='1.8.4',
+      version='1.8.10',
       description="Simplified PostgreSQL client built upon Psycopg2",
       maintainer="Gavin M. Roy",
       maintainer_email="gavinmroy@gmail.com",


### PR DESCRIPTION
Because hiding errors is bad for business and it makes @amberheilman have a bad day.