### PR TITLE
Implement Results.__bool__ method.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,5 +1,7 @@
 Version History
 ===============
+- Next Release
+  - Implement ``Results.__bool__`` to be explicit about Python 3 support.
 - 1.10.3 2017-11-01
   - Remove the functionality from ``TornadoSession.validate`` and make it raise a ``DeprecationWarning``
   - Catch the ``KeyError`` raised when ``PoolManager.clean()`` is invoked for a pool that doesn't exist

--- a/queries/results.py
+++ b/queries/results.py
@@ -59,6 +59,9 @@ class Results(object):
     def __nonzero__(self):
         return bool(self.cursor.rowcount)
 
+    def __bool__(self):
+        return self.__nonzero__()
+
     def __repr__(self):
         return '<queries.%s rows=%s>' % (self.__class__.__name__, len(self))
 


### PR DESCRIPTION
Python 3 dropped `__nonzero__` in preference to `__bool__`.  The code was only working because they seem to fall back to `__len__` if `__bool__` is not implemented.  This PR adds a `__bool__` implementation that simply calls `__nonzero__`.  _Explicit is better than implicit_ no?