### PR TITLE
Close the connection on a connecting error

### DIFF
--- a/queries/tornado_session.py
+++ b/queries/tornado_session.py
@@ -158,6 +158,7 @@ class TornadoSession(session.Session):
         """
         self._connections = dict()
         self._cleanup_callback = None
+        self._connecting = dict()
         self._cursor_factory = cursor_factory
         self._futures = dict()
         self._ioloop = io_loop or ioloop.IOLoop.current()
@@ -291,6 +292,7 @@ class TornadoSession(session.Session):
         # Add the connection for use in _poll_connection
         fd = connection.fileno()
         self._connections[fd] = connection
+        self._connecting[fd] = True
 
         def on_connected(cf):
             """Invoked by the IOLoop when the future is complete for the
@@ -303,7 +305,7 @@ class TornadoSession(session.Session):
                 future.set_exception(cf.exception())
 
             else:
-
+                self._connecting[fd] = False
                 try:
                     # Add the connection to the pool
                     LOGGER.debug('Connection established for %s', self.pid)
@@ -434,6 +436,8 @@ class TornadoSession(session.Session):
 
         if fd in self._connections:
             del self._connections[fd]
+        if fd in self._connecting:
+            del self._connecting[fd]
         if fd in self._futures:
             del self._futures[fd]
 
@@ -464,6 +468,18 @@ class TornadoSession(session.Session):
                 self._futures[fd].set_exception(
                     psycopg2.OperationalError('Connection error (%s)' % error)
                 )
+        except psycopg2.OperationalError as error:
+            if fd in self._futures and not self._futures[fd].done():
+                    self._futures[fd].set_exception(error)
+            if fd in self._connecting and self._connecting[fd]:
+                LOGGER.debug('OperationalError %s while connecting fd %s',
+                             error, fd)
+                self._ioloop.remove_handler(fd)
+                self._connections[fd].close()
+                del self._connections[fd]
+                del self._connecting[fd]
+                if fd in self._futures:
+                    del self._futures[fd]
         except (psycopg2.Error, psycopg2.Warning) as error:
             if fd in self._futures and not self._futures[fd].done():
                 self._futures[fd].set_exception(error)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -4,8 +4,10 @@ try:
 except ImportError:
     import unittest
 
-import queries
+from tornado import gen
 from tornado import testing
+
+import queries
 
 
 class SessionIntegrationTests(unittest.TestCase):
@@ -96,3 +98,29 @@ class TornadoSessionIntegrationTests(testing.AsyncTestCase):
             raise unittest.SkipTest('PostgreSQL is not running')
         self.assertEqual(6 % 4, result[0]['mod'])
         result.free()
+
+    @testing.gen_test
+    def test_polling_stops_after_connection_error(self):
+        # Abort the test right away if postgres isn't running.
+        good_uri = queries.uri('localhost', 5432, 'postgres', 'postgres')
+        try:
+            self.session = queries.Session(good_uri, pool_max_size=10)
+        except queries.OperationalError as error:
+            raise unittest.SkipTest(str(error).split('\n')[0])
+
+        # Use an invalid user to force an OperationalError during connection
+        bad_uri = queries.uri('localhost', 5432, 'invalid', 'invalid')
+        session = queries.TornadoSession(bad_uri)
+
+        self.count = 0
+        real_poll_connection = session._poll_connection
+
+        def count_polls(*args, **kwargs):
+            self.count += 1
+            real_poll_connection(*args, **kwargs)
+        session._poll_connection = count_polls
+
+        with self.assertRaises(queries.OperationalError):
+            yield session.query('SELECT 1')
+        yield gen.sleep(0.05)
+        self.assertLess(self.count, 20)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -104,7 +104,8 @@ class TornadoSessionIntegrationTests(testing.AsyncTestCase):
         # Abort the test right away if postgres isn't running.
         good_uri = queries.uri('localhost', 5432, 'postgres', 'postgres')
         try:
-            self.session = queries.Session(good_uri, pool_max_size=10)
+            test_session = queries.Session(good_uri, pool_max_size=10)
+            test_session.close()
         except queries.OperationalError as error:
             raise unittest.SkipTest(str(error).split('\n')[0])
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -125,3 +125,11 @@ class TornadoSessionIntegrationTests(testing.AsyncTestCase):
             yield session.query('SELECT 1')
         yield gen.sleep(0.05)
         self.assertLess(self.count, 20)
+
+    @testing.gen_test
+    def test_invalid_query(self):
+        try:
+            with self.assertRaises(queries.ProgrammingError):
+                yield self.session.query('INVALID QUERY')
+        except queries.OperationalError:
+            raise unittest.SkipTest('PostgreSQL is not running')


### PR DESCRIPTION
If an error message is returned from the server during the connecting phase, the socket will remain open after the error has been raised. The socket will continue to be polled forever, causing excessive CPU use.