### PR TITLE
Handle resultless statements when rowcount > 0

### DIFF
--- a/tests/results_tests.py
+++ b/tests/results_tests.py
@@ -32,6 +32,13 @@ class ResultsTestCase(unittest.TestCase):
             return self.obj[1]
         self.assertRaises(IndexError, get_row)
 
+    def test_getitem_raises_index_error_no_results(self):
+        self.cursor.rowcount = 1
+        self.cursor.fetchone = mock.Mock(
+            side_effect=psycopg2.ProgrammingError('no results to fetch'))
+        with self.assertRaises(IndexError):
+            self.obj[0]
+
     def test_getitem_invokes_fetchone(self):
         self.cursor.scroll = mock.Mock()
         self.cursor.fetchone = mock.Mock()
@@ -44,6 +51,12 @@ class ResultsTestCase(unittest.TestCase):
             [x for x in self.obj]
             assert not rewind.called, \
                 '_rewind should not be called on empty result'
+
+    def test_iter_on_no_results(self):
+        self.cursor.rowcount = 1
+        self.cursor.__iter__ = mock.Mock(
+            side_effect=psycopg2.ProgrammingError('no results to fetch'))
+        self.assertEqual(list(self.obj), [])
 
     def test_iter_rewinds(self):
         self.cursor.__iter__ = mock.Mock(return_value=iter([1, 2, 3]))
@@ -74,6 +87,12 @@ class ResultsTestCase(unittest.TestCase):
 
     def test_as_dict_no_rows(self):
         self.cursor.rowcount = 0
+        self.assertDictEqual(self.obj.as_dict(), {})
+
+    def test_as_dict_no_results(self):
+        self.cursor.rowcount = 1
+        self.cursor.fetchone = mock.Mock(
+            side_effect=psycopg2.ProgrammingError('no results to fetch'))
         self.assertDictEqual(self.obj.as_dict(), {})
 
     def test_as_dict_rewinds(self):
@@ -119,6 +138,12 @@ class ResultsTestCase(unittest.TestCase):
         self.cursor.fetchall = mock.Mock()
         self.obj.items()
         self.cursor.fetchall.assert_called_once_with()
+
+    def test_items_returns_empty_when_nothing_to_fetch(self):
+        self.cursor.rowcount = 1
+        self.cursor.fetchall = mock.Mock(
+            side_effect=psycopg2.ProgrammingError('no results to fetch'))
+        self.assertEqual(self.obj.items(), [])
 
     def test_rownumber_value(self):
         self.cursor.rownumber = 10


### PR DESCRIPTION
When, for example, an insert without return is executed, attempting to access the queries. Result object's rows raises a psycopg2.ProgrammingError with a message of 'no results to fetch'. The existing check in queries is based on cursor.rowcount and thus fails in this example as rowcount contains the number of rows affected - not necessarily returned.

This commit adds handling of said exception and matches the behaviors if the rowcount were 0.

Can be replicated by accessing the queries.Result object for an insert that inserts one or more rows without returning any results.

Example:
```
>>> result = session.query('insert into some_table (id) values (123)')
>>> list(result)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/storage1/queries/queries/results.py", line 48, in __iter__
    for row in self.cursor:
  File "/mnt/storage1/queries/env/lib/python3.6/site-packages/psycopg2-2.7.5-py3.6-linux-x86_64.egg/psycopg2/extras.py", line 117, in __iter__
    first = next(res)
psycopg2.ProgrammingError: no results to fetch
```

Handling of the error should probably be abstracted.