### PR TITLE
Add ability to override autocommit option for the session.

### DIFF
--- a/queries/session.py
+++ b/queries/session.py
@@ -253,7 +253,10 @@ class Session(object):
         self._cleanup()
 
     def _autocommit(self, autocommit):
-        """Set the isolation level automatically to commit after every query"""
+        """Set the isolation level automatically to commit or not after every query
+        
+        :param autocommit: Boolean (Default - True)
+        """
         self._conn.autocommit = autocommit
 
     def _cleanup(self):

--- a/queries/session.py
+++ b/queries/session.py
@@ -70,7 +70,7 @@ class Session(object):
     def __init__(self, uri=DEFAULT_URI,
                  cursor_factory=extras.RealDictCursor,
                  pool_idle_ttl=pool.DEFAULT_IDLE_TTL,
-                 pool_max_size=pool.DEFAULT_MAX_SIZE
+                 pool_max_size=pool.DEFAULT_MAX_SIZE,
                  autocommit=True):
         """Connect to a PostgreSQL server using the module wide connection and
         set the isolation level.

--- a/queries/session.py
+++ b/queries/session.py
@@ -70,7 +70,8 @@ class Session(object):
     def __init__(self, uri=DEFAULT_URI,
                  cursor_factory=extras.RealDictCursor,
                  pool_idle_ttl=pool.DEFAULT_IDLE_TTL,
-                 pool_max_size=pool.DEFAULT_MAX_SIZE):
+                 pool_max_size=pool.DEFAULT_MAX_SIZE
+                 autocommit=True):
         """Connect to a PostgreSQL server using the module wide connection and
         set the isolation level.
 
@@ -90,7 +91,7 @@ class Session(object):
         self._conn = self._connect()
         self._cursor_factory = cursor_factory
         self._cursor = self._get_cursor(self._conn)
-        self._autocommit()
+        self._autocommit(autocommit)
 
     @property
     def backend_pid(self):
@@ -251,9 +252,9 @@ class Session(object):
         """
         self._cleanup()
 
-    def _autocommit(self):
+    def _autocommit(self, autocommit):
         """Set the isolation level automatically to commit after every query"""
-        self._conn.autocommit = True
+        self._conn.autocommit = autocommit
 
     def _cleanup(self):
         """Remove the connection from the stack, closing out the cursor"""

--- a/tests/session_tests.py
+++ b/tests/session_tests.py
@@ -165,7 +165,7 @@ class SessionTestCase(unittest.TestCase):
 
     def test_autocommit_sets_attribute(self):
         self.conn.autocommit = False
-        self.obj._autocommit()
+        self.obj._autocommit(True)
         self.assertTrue(self.conn.autocommit)
 
     def test_cleanup_closes_cursor(self):


### PR DESCRIPTION
There could be cases when someone wants to execute multiple write queries and run it entirely as a transaction (as opposed to each query being committed). 
In its current implementation, you cannot override the session's autocommit policy without having to access private attributes.